### PR TITLE
Guard against network related race conditions

### DIFF
--- a/src/shared/components/PostOr404.tsx
+++ b/src/shared/components/PostOr404.tsx
@@ -46,6 +46,8 @@ type State = {
 };
 
 class PostOr404 extends React.Component<Props, State> {
+  mounted: boolean;
+
   constructor(props: Props) {
     super(props);
 
@@ -67,6 +69,7 @@ class PostOr404 extends React.Component<Props, State> {
   }
 
   public componentDidMount(): void {
+    this.mounted = true;
     if (!this.state.post) {
       const { slug } = this.props;
       this.fetchPost(slug);
@@ -98,14 +101,28 @@ class PostOr404 extends React.Component<Props, State> {
     return <Post {...post} />;
   }
 
+  public componentWillUnmount(): void {
+    this.mounted = false;
+  }
+
   private fetchPost(slug: string): void {
     const url = `/api/posts/${slug}`;
-    this.setState({ loading: true }, () =>
-      this.props
-        .get(url)
-        .then(post => this.setState({ post, loading: false }))
-        .catch(error => this.setState({ error, loading: false }))
-    );
+    this.setState({ loading: true }, () => {
+      if (this.mounted) {
+        this.props
+          .get(url)
+          .then(post => {
+            if (this.mounted) {
+              this.setState({ post, loading: false });
+            }
+          })
+          .catch(error => {
+            if (this.mounted) {
+              this.setState({ error, loading: false });
+            }
+          });
+      }
+    });
   }
 }
 

--- a/src/shared/components/PostOr404.tsx
+++ b/src/shared/components/PostOr404.tsx
@@ -46,7 +46,7 @@ type State = {
 };
 
 class PostOr404 extends React.Component<Props, State> {
-  mounted: boolean;
+  private mounted: boolean;
 
   constructor(props: Props) {
     super(props);

--- a/src/shared/components/PostOr404.tsx
+++ b/src/shared/components/PostOr404.tsx
@@ -107,22 +107,20 @@ class PostOr404 extends React.Component<Props, State> {
 
   private fetchPost(slug: string): void {
     const url = `/api/posts/${slug}`;
-    this.setState({ loading: true }, () => {
-      if (this.mounted) {
-        this.props
-          .get(url)
-          .then(post => {
-            if (this.mounted) {
-              this.setState({ post, loading: false });
-            }
-          })
-          .catch(error => {
-            if (this.mounted) {
-              this.setState({ error, loading: false });
-            }
-          });
-      }
-    });
+    this.setState({ loading: true }, () =>
+      this.props
+        .get(url)
+        .then(post => {
+          if (this.mounted) {
+            this.setState({ post, loading: false });
+          }
+        })
+        .catch(error => {
+          if (this.mounted) {
+            this.setState({ error, loading: false });
+          }
+        })
+    );
   }
 }
 

--- a/src/shared/components/Posts.tsx
+++ b/src/shared/components/Posts.tsx
@@ -44,7 +44,7 @@ type State = {
 };
 
 class Posts extends React.Component<Props, State> {
-  mounted: boolean;
+  private mounted: boolean;
 
   constructor(props: Props) {
     super(props);

--- a/src/shared/components/Posts.tsx
+++ b/src/shared/components/Posts.tsx
@@ -133,24 +133,21 @@ class Posts extends React.Component<Props, State> {
 
   private fetchPosts(tag?: string): void {
     const url = `/api/posts${tag === undefined ? "" : `?tag=${tag}`}`;
-    this.setState({ loading: true }, () => {
-      // Guard against a race condition where the state updates despite the user navigating away
-      // This can happen when running on low powered devuces or against slow networks
-      if (this.mounted) {
-        this.props
-          .get(url)
-          .then(posts => {
-            if (this.mounted) {
-              this.setState({ posts, loading: false });
-            }
-          })
-          .catch(error => {
-            if (this.mounted) {
-              this.setState({ error, loading: false });
-            }
-          });
-      }
-    });
+    this.setState({ loading: true }, () =>
+      this.props
+        .get(url)
+        .then(posts => {
+          // Guard against races that occur on slow networks
+          if (this.mounted) {
+            this.setState({ posts, loading: false });
+          }
+        })
+        .catch(error => {
+          if (this.mounted) {
+            this.setState({ error, loading: false });
+          }
+        })
+    );
   }
 }
 


### PR DESCRIPTION
When a user navigates away before a network request completes, React will complain that it cannot update an unmounted DOM node. This is due to asynchronous `setState` calls. The warning manifests itself on slow network connections. To mitigate the problem in most situations we can either:

1. **Check to see whether the component is mounted before setting state**
2. Cancel the network request when the component unmounts

The first approach can leave many connections open if the user rapidly navigates. 