### PR TITLE
Guard against network related race conditions

### DIFF
--- a/src/shared/components/Posts.tsx
+++ b/src/shared/components/Posts.tsx
@@ -138,9 +138,9 @@ class Posts extends React.Component<Props, State> {
         .then(posts => this.setState({ posts, loading: false }))
         .catch(error => {
           if (error.name !== "AbortError") {
-            // User navigated away
             this.setState({ error, loading: false });
           }
+          // User navigated away
         })
     );
   }

--- a/src/shared/hocs/withClient.tsx
+++ b/src/shared/hocs/withClient.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { get } from "shared/http";
 
 interface Props<P> {
-  get(url: string): Promise<P>;
+  get(url: string, signal: AbortSignal): Promise<P>;
 }
 
 export default function<P>(Component: React.FC<Props<P>>) {

--- a/src/shared/http.ts
+++ b/src/shared/http.ts
@@ -8,10 +8,11 @@ export class RequestError extends Error {
   }
 }
 
-export function get<P>(url: string): Promise<P> {
+export function get<P>(url: string, signal: AbortSignal): Promise<P> {
   return fetch(url, {
     method: "get",
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json" },
+    signal
   }).then(res =>
     res
       .json()

--- a/tests/components/post.test.tsx
+++ b/tests/components/post.test.tsx
@@ -66,7 +66,10 @@ describe("<PostOr404 />", () => {
         </MemoryRouter>
       );
       return mockPromise.then(() => {
-        expect(get).toHaveBeenCalledWith(`/api/posts/${slug}`);
+        expect(get).toHaveBeenCalledWith(
+          `/api/posts/${slug}`,
+          expect.anything()
+        );
       });
     });
 

--- a/tests/components/posts.test.tsx
+++ b/tests/components/posts.test.tsx
@@ -116,7 +116,10 @@ describe("<Posts />", () => {
         </MemoryRouter>
       );
       return mockPromise.then(() => {
-        expect(get).toHaveBeenCalledWith(`/api/posts?tag=${tag}`);
+        expect(get).toHaveBeenCalledWith(
+          `/api/posts?tag=${tag}`,
+          expect.anything()
+        );
       });
     });
 


### PR DESCRIPTION
When a user navigates away before a network request completes, React will complain that it cannot update an unmounted DOM node. This is due to asynchronous `setState` calls. The warning manifests itself on slow network connections. To mitigate the problem in most situations we can either:

1. Check to see whether the component is mounted before setting state
2. **Cancel the network request when the component unmounts**

The first approach can leave many connections open if the user rapidly navigates. 